### PR TITLE
Proposition to fix issue #2

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -8,6 +8,19 @@ miniProxy is licensed under the GNU GPL v3 <http://www.gnu.org/licenses/gpl.html
 ob_start("ob_gzhandler");
 
 if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
+if (!function_exists('getallheaders')) { 
+        function getallheaders() { 
+            foreach($_SERVER as $key=>$value) { 
+                if (substr($key,0,5)=="HTTP_") { 
+                    $key=str_replace(" ","-",ucwords(strtolower(str_replace("_"," ",substr($key,5))))); 
+                    $out[$key]=$value; 
+                }else{ 
+                    $out[$key]=$value; 
+        } 
+            } 
+            return $out; 
+        } 
+} 
 
 define("PROXY_PREFIX", "http://" . $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["SCRIPT_NAME"] . "/");
 


### PR DESCRIPTION
As said in the issue #2 when php is running as CGI and not an pache mod the following error appears:

> Call to undefined function getallheaders() on line 26

In the pull request I declare the function getallheaders when it doesn't exist.
