### PR TITLE
Proxy urls do not respect https://

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -25,7 +25,7 @@ if (!function_exists("getallheaders")) {
   }
 }
 
-define("PROXY_PREFIX", "http://" . $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["SCRIPT_NAME"] . "/");
+define("PROXY_PREFIX", "http".($_SERVER['HTTPS'] ? 's' : '')."://" . $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["SCRIPT_NAME"] . "/");
 
 //Makes an HTTP request via cURL, using request data that was passed directly to this script.
 function makeRequest($url) {


### PR DESCRIPTION
I have added a simple $_SERVER['https'] check to the proxy prefix to make sure that subsequent requests are also delivered via SSL with the https prefix. Although the port is set, my Chromium refuses to load site resources via http://example.com:443 but allows them over https://example.com:443.
