### PR TITLE
Fix GET parameters handling

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -59,19 +59,6 @@ function makeRequest($url) {
 
   //Proxy any received GET/POST/PUT data.
   switch ($_SERVER["REQUEST_METHOD"]) {
-    case "GET":
-      $getData = array();
-      foreach ($_GET as $key => $value) {
-          $getData[] = urlencode($key) . "=" . urlencode($value);
-      }
-      if (count($getData) > 0) {
-        //Remove any GET data from the URL, and re-add what was read.
-        //TODO: Is the code in this "GET" case necessary?
-        //It reads, strips, then re-adds all GET data; this may be a no-op.
-        $url = substr($url, 0, strrpos($url, "?"));
-        $url .= "?" . implode("&", $getData);
-      }
-    break;
     case "POST":
       curl_setopt($ch, CURLOPT_POST, true);
       //For some reason, $HTTP_RAW_POST_DATA isn't working as documented at


### PR DESCRIPTION
The current GET parameters handling is incorrect and not needed. The issue is with parameters that include only a key and no value. This is common with WSDL services that often include a value-less parameter
called "wsdl". The current code assumes there's a value, so it adds the key to the URL with an equality sign. This can cause the web service to fail and we won't get the original response.

The solution is really simple, just remove this piece of code.

To see this in action, try to proxy the following URL with and without the fix: http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL
