### PR TITLE
Fixing URLs that include only one slash (IIS issue)

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -153,10 +153,20 @@ function proxifyCSS($css, $baseURL) {
     $css);
 }
 
+// Parse/extract URL
 $url = substr($_SERVER["REQUEST_URI"], strlen($_SERVER["SCRIPT_NAME"]) + 1);
-if (empty($url)) die("<html><head><title>miniProxy</title></head><body><h1>Welcome to miniProxy!</h1>miniProxy can be directly invoked like this: <a href=\"" . PROXY_PREFIX . "http://google.com/\">" . PROXY_PREFIX . "http://google.com/</a><br /><br />Or, you can simply enter a URL below:<br /><br /><form onsubmit=\"window.location.href='" . PROXY_PREFIX . "' + document.getElementById('site').value; return false;\"><input id=\"site\" type=\"text\" size=\"50\" /><input type=\"submit\" value=\"Proxy It!\" /></form></body></html>");
-if (strpos($url, "//") === 0) $url = "http:" . $url; //Assume that any supplied URLs starting with // are HTTP URLs.
-if (!preg_match("@^.*://@", $url)) $url = "http://" . $url; //Assume that any supplied URLs without a scheme are HTTP URLs.
+if (empty($url)) {
+    die("<html><head><title>miniProxy</title></head><body><h1>Welcome to miniProxy!</h1>miniProxy can be directly invoked like this: <a href=\"" . PROXY_PREFIX . "http://google.com/\">" . PROXY_PREFIX . "http://google.com/</a><br /><br />Or, you can simply enter a URL below:<br /><br /><form onsubmit=\"window.location.href='" . PROXY_PREFIX . "' + document.getElementById('site').value; return false;\"><input id=\"site\" type=\"text\" size=\"50\" /><input type=\"submit\" value=\"Proxy It!\" /></form></body></html>");
+} else if (strpos($url, "//") === 0) {
+    $url = "http:" . $url; //Assume that any supplied URLs starting with // are HTTP URLs.
+} else if (strpos($url, ':/') !== strpos($url, '://')) {
+    // Some web servers (e.g. IIS 8.5) modify double slash in query string to a single slash, before we can proxy the
+    // URL we need to fix this.
+    $pos = strpos($url, ':/');
+    $url = substr_replace($url, '://', $pos, strlen(':/'));
+} else if (!preg_match("@^.*://@", $url)) {
+    $url = "http://" . $url; //Assume that any supplied URLs without a scheme are HTTP URLs.
+}
 
 $response = makeRequest($url);
 $rawResponseHeaders = $response["headers"];


### PR DESCRIPTION
Some web servers such as IIS 8.5, modify URLs by replacing double slash to single slash. This means that PHP will get a bad URL and we will fail to proxy it.
For example when the user passes "http://www.google.com" to miniProxy, the script will actually get "http:/www.google.com".
The fix checks for this issue and if needed adds the missing slash.

For more information about this issue, see:
http://stackoverflow.com/questions/11130512/iis-modifies-double-slash-to-single-slash-in-querystring