### PR TITLE
New feature: add CORS support

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,8 @@
+<?php
+
+/*** Configuration ***/
+
+/**
+ * Set $forceCORS to true if you want to allow "Cross-Origin Resource Sharing" with the proxied site.
+ */
+$forceCORS = false;

--- a/config.php
+++ b/config.php
@@ -1,8 +1,0 @@
-<?php
-
-/*** Configuration ***/
-
-/**
- * Set $forceCORS to true if you want to allow "Cross-Origin Resource Sharing" with the proxied site.
- */
-$forceCORS = false;

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -5,7 +5,34 @@ Written and maintained by Joshua Dick <http://joshdick.net>.
 miniProxy is licensed under the GNU GPL v3 <http://www.gnu.org/licenses/gpl.html>.
 */
 
+require_once __DIR__ . '/config.php';
+
 ob_start("ob_gzhandler");
+
+function enableCORS() {
+    // This function is based on a disscussion from: http://stackoverflow.com/questions/8719276/cors-with-php-headers
+
+    // Allow access from any origin
+    header("Access-Control-Allow-Origin: *");
+    header('Access-Control-Allow-Credentials: true');
+
+    // Handle Access-Control headers received during an OPTIONS request
+    if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+	if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
+	    header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+	}
+
+	if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
+	    header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+	}
+
+	exit(0);
+    }
+}
+
+if ($forceCORS) {
+    enableCORS();
+}
 
 if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
 

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -5,39 +5,35 @@ Written and maintained by Joshua Dick <http://joshdick.net>.
 miniProxy is licensed under the GNU GPL v3 <http://www.gnu.org/licenses/gpl.html>.
 */
 
-/*** Configuration ***/
+/****************************** START CONFIGURATION ******************************/
 
-// Set $forceCORS to true if you want to allow "Cross-Origin Resource Sharing" with the proxied site.
+//Set $forceCORS to true if you want to allow "Cross-Origin Resource Sharing" with the proxied site.
 $forceCORS = false;
 
-
-/*** Code ***/
+/****************************** END CONFIGURATION ******************************/
 
 ob_start("ob_gzhandler");
 
 function enableCORS() {
-    // This function is based on a discussion from: http://stackoverflow.com/questions/8719276/cors-with-php-headers
+  //This function is based on a discussion from: http://stackoverflow.com/questions/8719276/cors-with-php-headers
 
-    // Allow access from any origin
-    header("Access-Control-Allow-Origin: *");
-    header('Access-Control-Allow-Credentials: true');
+  //Allow access from any origin
+  header("Access-Control-Allow-Origin: *");
+  header('Access-Control-Allow-Credentials: true');
 
-    // Handle Access-Control headers received during an OPTIONS request
-    if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-	if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
-	    header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-	}
-
-	if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
-	    header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
-	}
-
-	exit(0);
+  //Handle Access-Control headers received during an OPTIONS request
+  if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
+      header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
     }
-}
 
-if ($forceCORS) {
-    enableCORS();
+    if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
+      header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+    }
+
+    // It's an OPTIONS request so we just need to send the headers and exit
+    exit(0);
+  }
 }
 
 if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
@@ -206,6 +202,11 @@ foreach ($headerLines as $header) {
   if (stripos($header, "Content-Length") === false && stripos($header, "Transfer-Encoding") === false) {
     header($header);
   }
+}
+
+if ($forceCORS) {
+    //For enabling CORS we might need to add headers to the response, so it's important for this to happen after adding the response headers from cURL to prevent an overwrite
+    enableCORS();
 }
 
 $contentType = "";

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -5,12 +5,18 @@ Written and maintained by Joshua Dick <http://joshdick.net>.
 miniProxy is licensed under the GNU GPL v3 <http://www.gnu.org/licenses/gpl.html>.
 */
 
-require_once __DIR__ . '/config.php';
+/*** Configuration ***/
+
+// Set $forceCORS to true if you want to allow "Cross-Origin Resource Sharing" with the proxied site.
+$forceCORS = false;
+
+
+/*** Code ***/
 
 ob_start("ob_gzhandler");
 
 function enableCORS() {
-    // This function is based on a disscussion from: http://stackoverflow.com/questions/8719276/cors-with-php-headers
+    // This function is based on a discussion from: http://stackoverflow.com/questions/8719276/cors-with-php-headers
 
     // Allow access from any origin
     header("Access-Control-Allow-Origin: *");


### PR DESCRIPTION
When a developer is working on a website/webapp that is accessing miniProxy using AJAX, the developer might have issues with CORS (Cross-origin resource sharing) that will prevent him/her from getting
the proxified data. For example if the webapp and the service are not on the same domain, the browser will block the request.
I added a way to easily enable CORS support. All the developer needs to do is edit config.php and set $forceCORS to true (the default is false, which will act exactly as before).

Using this will make it a lot easier to use the service through AJAX.