### PR TITLE
Port must be before path when building a URL

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -154,7 +154,7 @@ function rel2abs($rel, $base) {
     }
     $auth .= "@";
   }
-  $abs = "$auth$host$path$port/$rel"; //Dirty absolute URL
+  $abs = "$auth$host$port$path/$rel"; //Dirty absolute URL
   for ($n = 1; $n > 0; $abs = preg_replace(array("#(/\.?/)#", "#/(?!\.\.)[^/]+/\.\./#"), "/", $abs, -1, $n)) {} //Replace '//' or '/./' or '/foo/../' with '/'
   return $scheme . "://" . $abs; //Absolute URL is ready.
 }


### PR DESCRIPTION
There was a bug un rel2abs: the port was inserted after the path, whereas it should be between the host and the path. This pull request corrects this.