### PR TITLE
support proxy for proxy server

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -22,8 +22,8 @@ $whitelistPatterns = array(
 $forceCORS = false;
 
 function _proxy_setting(&$ch){
-  curl_setopt($ch,CURLOPT_PROXY,'139.224.226.214');
-  curl_setopt($ch,CURLOPT_PROXYPORT, 5021);
+  curl_setopt($ch,CURLOPT_PROXY,'127.0.0.1');
+  curl_setopt($ch,CURLOPT_PROXYPORT, 8080);
   curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 20);
   curl_setopt($ch,CURLOPT_PROXYTYPE,CURLPROXY_SOCKS5);
   // curl_setopt($ch,CURLOPT_PROXYAUTH,CURLAUTH_BASIC);

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -22,10 +22,10 @@ $whitelistPatterns = array(
 $forceCORS = false;
 
 function _proxy_setting(&$ch){
-  curl_setopt($ch,CURLOPT_PROXY,'127.0.0.1');
-  curl_setopt($ch,CURLOPT_PROXYPORT, 8080);
-  curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 20);
-  curl_setopt($ch,CURLOPT_PROXYTYPE,CURLPROXY_SOCKS5);
+  // curl_setopt($ch,CURLOPT_PROXY,'127.0.0.1');
+  // curl_setopt($ch,CURLOPT_PROXYPORT, 8080);
+  // curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 20);
+  // curl_setopt($ch,CURLOPT_PROXYTYPE,CURLPROXY_SOCKS5);
   // curl_setopt($ch,CURLOPT_PROXYAUTH,CURLAUTH_BASIC);
   // curl_setopt($ch,CURLOPT_PROXYUSERPWD,'[User]:[Pwd] ');
   return $ch;

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -21,6 +21,16 @@ $whitelistPatterns = array(
 //To enable CORS (cross-origin resource sharing) for proxied sites, set $forceCORS to true.
 $forceCORS = false;
 
+function _proxy_setting(&$ch){
+  curl_setopt($ch,CURLOPT_PROXY,'139.224.226.214');
+  curl_setopt($ch,CURLOPT_PROXYPORT, 5021);
+  curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 20);
+  curl_setopt($ch,CURLOPT_PROXYTYPE,CURLPROXY_SOCKS5);
+  // curl_setopt($ch,CURLOPT_PROXYAUTH,CURLAUTH_BASIC);
+  // curl_setopt($ch,CURLOPT_PROXYUSERPWD,'[User]:[Pwd] ');
+  return $ch;
+}
+
 /****************************** END CONFIGURATION ******************************/
 
 ob_start("ob_gzhandler");
@@ -135,6 +145,7 @@ function makeRequest($url) {
 
   //Set the request URL.
   curl_setopt($ch, CURLOPT_URL, $url);
+  function_exists('_proxy_setting') && $ch=_proxy_setting($ch);
 
   //Make the request.
   $response = curl_exec($ch);


### PR DESCRIPTION
Scenario 1: the proxy server bandwidth is relatively small, there is no limit to the bandwidth, faster, so the host with the LAN request proxy server services.
Scenario 2: When there are multiple proxy server, you can easily switch configuration