### PR TITLE
Fix 433 on URL if over HTTPS

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -68,7 +68,11 @@ if (!function_exists("getallheaders")) {
   }
 }
 
-$prefixPort = $_SERVER["SERVER_PORT"] != 80 ? ":" . $_SERVER["SERVER_PORT"] : "";
+if( (!isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] = 80) || (isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] = 433)){
+$prefixPort = "";
+}else{
+$prefixPort = ":" . $_SERVER["SERVER_PORT"];
+}
 //Use HTTP_HOST to support client-configured DNS (instead of SERVER_NAME), but remove the port if one is present
 $prefixHost = $_SERVER["HTTP_HOST"];
 $prefixHost = strpos($prefixHost, ":") ? implode(":", explode(":", $_SERVER["HTTP_HOST"], -1)) : $prefixHost;

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -68,7 +68,7 @@ if (!function_exists("getallheaders")) {
   }
 }
 
-if( (!isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] = 80) || (isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] = 433)){
+if( (!isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] == 80) || (isset($_SERVER["HTTPS"]) && $_SERVER["SERVER_PORT"] == 433)){
 $prefixPort = "";
 }else{
 $prefixPort = ":" . $_SERVER["SERVER_PORT"];


### PR DESCRIPTION
The small fix removes the standard-port of HTTPS (433) from the direct URL if the page is called over HTTPS (and adds it if called over HTTPS but on Port 80)