### PR TITLE
Configs

### DIFF
--- a/config/example.net.php
+++ b/config/example.net.php
@@ -1,0 +1,39 @@
+<?php
+/*This is an example config file for miniProxy with some examples, these configs are most usefull for changing php cURL options.
+Read more on cURL
+http://php.net/manual/en/book.curl.php
+http://php.net/manual/en/ref.curl.php
+
+To make your own config file create a file called website_domain.php;
+For example to make a config for Facebook you would make a config file called facebook.com.php, prefixes to domains such as 'm.' must be taken into consideration.
+If you wanted a config for mobile facebok the file would be called m.facebok.com.php. The only prefix that must not be taken into consideration is 'www.'
+
+Put you cURL config and other scripts into the .php file you created and surround them with(just like this one)
+<?php
+
+?>
+*/
+
+	//Atempt to report the users real IP (fixes security message on Facebook)
+	curl_setopt($ch, CURLOPT_HTTPHEADER, array("X-Forwarded-For: $ip"));
+
+
+/*Some user agents you may want
+I.E 8.0:					Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)
+I.E 11.0:					Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)
+Firefox on windows: 		Mozilla/5.0 (Windows NT 6.2; WOW64; rv:21.0) Gecko/20100101 Firefox/21.0
+Nexus 7 (Android phone) 	Mozilla/5.0 (Linux; Android 4.1.1; Nexus 7 Build/JRO03D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Galaxy S4(Android phone)	Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Firefox on Android phone	Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0
+Firefox on Android tablet	Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0
+	*/
+//Override the user agent. List of user agents: https://udger.com/resources/ua-list (this scripts uses I.E 8.0)
+	$user_agent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)";
+	curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);
+	
+	//cURL Cookies (Please see https://github.com/joshdick/miniProxy/pull/69)
+	//session_start();
+	//curl_setopt($ch, CURLOPT_COOKIEJAR, cookies.txt);
+    //curl_setopt($ch, CURLOPT_COOKIEFILE, cookies.txt);
+//We don't want to make cookies :) ^^^
+?>

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -139,6 +139,11 @@ function makeRequest($url) {
   curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
+  //Load a config for a website.
+  $domain = str_ireplace('www.', '', parse_url($url, PHP_URL_HOST));
+  if (file_exists(realpath("config/$domain.php"))) {   
+        include realpath("config/$domain.php");             
+    }
   //Set the request URL.
   curl_setopt($ch, CURLOPT_URL, $url);
 

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -26,8 +26,10 @@ $forceCORS = false;
 //if the URL form is left blank.
 $exampleURL = 'https://example.net';
 
-/****************************** END CONFIGURATION ******************************/
+//Enable Cookies
+$enablecookies = false;
 
+/****************************** END CONFIGURATION ******************************/
 ob_start("ob_gzhandler");
 
 if (version_compare(PHP_VERSION, "5.4.7", "<")) {
@@ -138,12 +140,32 @@ function makeRequest($url) {
   curl_setopt($ch, CURLOPT_HEADER, true);
   curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
   //Load a config for a website.
   $domain = str_ireplace('www.', '', parse_url($url, PHP_URL_HOST));
   if (file_exists(realpath("config/$domain.php"))) {   
         include realpath("config/$domain.php");             
     }
+ //Function can be called, but isn't coded to delete cookies correctly 
+  if ($url == "cleancookie") {
+	$mask = sys_get_temp_dir() . "cookiefile_";
+	die('Detected Cookies: "' . glob($mask) . '" Have been deleted');
+	array_map('unlink', glob($mask));
+  }
+  
+  if (!enablecookies) {
+	//No use for this right now.. 
+  } else {
+	session_start();
+	
+	$parseUrl = parse_url(trim($url));
+	$host = trim($parseUrl['host'] ? $parseUrl['host'] : array_shift(explode('/', $parseUrl['path'], 2))); // http://stackoverflow.com/a/1974047/278810
+	
+	//This doesn't work on my server, so maybe it's broken? (ended up replacing it with "cookiefile_" . session_id() . "_" . $host; and setting the path to be "tmp/$cookieFile" rather than $cookieFile
+		$cookieFile = sys_get_temp_dir() . "cookiefile_" . session_id() . "_" . $host;
+		curl_setopt($ch, CURLOPT_COOKIEJAR,$cookieFile);
+		curl_setopt($ch, CURLOPT_COOKIEFILE, $cookieFile);
+}
+
   //Set the request URL.
   curl_setopt($ch, CURLOPT_URL, $url);
 
@@ -250,13 +272,14 @@ if (isset($_POST["miniProxyFormAction"])) {
   }
 }
 if (empty($url)) {
-    die("<html><head><title>miniProxy</title></head><body><h1>Welcome to miniProxy!</h1>miniProxy can be directly invoked like this: <a href=\"" . PROXY_PREFIX . $exampleURL . "\">" . PROXY_PREFIX . $exampleURL . "</a><br /><br />Or, you can simply enter a URL below:<br /><br /><form onsubmit=\"if (document.getElementById('site').value) { window.location.href='" . PROXY_PREFIX . "' + document.getElementById('site').value; return false; } else { window.location.href='" . PROXY_PREFIX . $exampleURL . "'; return false; }\" autocomplete=\"off\"><input id=\"site\" type=\"text\" size=\"50\" /><input type=\"submit\" value=\"Proxy It!\" /></form></body></html>");
+   die("<html><head><title>miniProxy</title></head><body><h1>Welcome to miniProxy!</h1>miniProxy can be directly invoked like this: <a href=\"" . PROXY_PREFIX . $exampleURL . "\">" . PROXY_PREFIX . $exampleURL . "</a><br /><br />Or, you can simply enter a URL below:<br /><br /><form onsubmit=\"if (document.getElementById('site').value) { window.location.href='" . PROXY_PREFIX . "' + document.getElementById('site').value; return false; } else { window.location.href='" . PROXY_PREFIX . $exampleURL . "'; return false; }\" autocomplete=\"off\"><input id=\"site\" type=\"text\" size=\"50\" /><input type=\"submit\" value=\"Proxy It!\" /></form></body></html>");
 } else if (strpos($url, ":/") !== strpos($url, "://")) {
     //Work around the fact that some web servers (e.g. IIS 8.5) change double slashes appearing in the URL to a single slash.
     //See https://github.com/joshdick/miniProxy/pull/14
     $pos = strpos($url, ":/");
     $url = substr_replace($url, "://", $pos, strlen(":/"));
 }
+	
 $scheme = parse_url($url, PHP_URL_SCHEME);
 if (empty($scheme)) {
   //Assume that any supplied URLs starting with // are HTTP URLs.

--- a/plugins/facebook.com.php
+++ b/plugins/facebook.com.php
@@ -1,0 +1,9 @@
+<?php
+$enablecookies = true;
+
+//Fix for the security message 
+curl_setopt($ch, CURLOPT_HTTPHEADER, array("X-Forwarded-For: $ip"));
+	//Tells Facebook to use a old version for better compatiblity with MiniProxy
+	$user_agent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)";
+	curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);
+?>

--- a/plugins/m.facebook.com.php
+++ b/plugins/m.facebook.com.php
@@ -1,0 +1,9 @@
+<?php
+$enablecookies = true;
+
+//Fix for the security message 
+curl_setopt($ch, CURLOPT_HTTPHEADER, array("X-Forwarded-For: $ip"));
+	//Tells Facebook to use a old version for better compatiblity with MiniProxy
+	$user_agent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)";
+	curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);
+?>


### PR DESCRIPTION
- Domain configs, best used for cURL. For examples read the `example.net.php` file.
- You don't have to include the config folder for MiniProxy to continue to work, without them it will function as normal so MiniProxy can still be just as mini if the user would like :)
- Created a sample config file for example.net

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshdick/miniproxy/74)
<!-- Reviewable:end -->
