### PR TITLE
Fixed: Ajax calls sometimes adds base url when it already is added

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -507,7 +507,9 @@ if (stripos($contentType, "text/html") !== false) {
               if (arguments[1] !== null && arguments[1] !== undefined) {
                 var url = arguments[1];
                 url = rel2abs("' . $url . '", url);
-                url = "' . PROXY_PREFIX . '" + url;
+                if (url.search("' . PROXY_PREFIX . '") == -1) {
+                  url = "' . PROXY_PREFIX . '" + url;
+                }
                 arguments[1] = url;
               }
               return proxied.apply(this, [].slice.call(arguments));

--- a/miniProxy.php
+++ b/miniProxy.php
@@ -507,7 +507,7 @@ if (stripos($contentType, "text/html") !== false) {
               if (arguments[1] !== null && arguments[1] !== undefined) {
                 var url = arguments[1];
                 url = rel2abs("' . $url . '", url);
-                if (url.search("' . PROXY_PREFIX . '") == -1) {
+                if (url.indexOf("' . PROXY_PREFIX . '") == -1) {
                   url = "' . PROXY_PREFIX . '" + url;
                 }
                 arguments[1] = url;


### PR DESCRIPTION
Sometimes the url used in `window.XMLHttpRequest.prototype.open` aleady is proxiefied and that results in a double base url. This fixes that. (Fixes: #79 )