### PR TITLE
Fixed bug during check of removed headers.

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -68,7 +68,7 @@ function removeKeys(&$assoc, $keys2remove) {
     $key = strtolower($key);
     if (isset($map[$key])) {
       unset($assoc[$map[$key]]);
-      $removedKeys[] = $map[$key];
+      $removedKeys[] = strtolower($map[$key]);
     }
   }
   return $removedKeys;
@@ -120,8 +120,6 @@ function makeRequest($url) {
     "Origin"
   ));
 
-  array_change_key_case($removedHeaders, CASE_LOWER);
-
   curl_setopt($ch, CURLOPT_ENCODING, "");
   //Transform the associative array from getallheaders() into an
   //indexed array of header strings to be passed to cURL.
@@ -134,7 +132,7 @@ function makeRequest($url) {
   }
   //Any `origin` header sent by the browser will refer to the proxy itself.
   //If an `origin` header is present in the request, rewrite it to point to the correct origin.
-  if (array_key_exists('origin', $removedHeaders)) {
+  if (in_array('origin', $removedHeaders)) {
     $urlParts = parse_url($url);
     $port = $urlParts['port'];
     $curlRequestHeaders[] = "Origin: " . $urlParts['scheme'] . "://" . $urlParts['host'] . (empty($port) ? "" : ":" . $port);


### PR DESCRIPTION
The function checks if inside keys of array exist "origin", instead removeKey function return an array that contains the removed elements. I inserted strtolower function to insert in to array the removed elements in order to not search elements with upper case characters. 