### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/miniProxy.php
+++ b/miniProxy.php
@@ -445,14 +445,14 @@ if (stripos($contentType, "text/html") !== false) {
 
   $head = $xpath->query("//head")->item(0);
   $body = $xpath->query("//body")->item(0);
-  $prependElem = $head != NULL ? $head : $body;
+  $prependElem = $head != null ? $head : $body;
 
   //Only bother trying to apply this hack if the DOM has a <head> or <body> element;
   //insert some JavaScript at the top of whichever is available first.
   //Protects against cases where the server sends a Content-Type of "text/html" when
   //what's coming back is most likely not actually HTML.
   //TODO: Do this check before attempting to do any sort of DOM parsing?
-  if ($prependElem != NULL) {
+  if ($prependElem != null) {
 
     $scriptElem = $doc->createElement("script",
       '(function() {


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!